### PR TITLE
docs: add copilot instructions file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+# Copilot Instructions
+
+Use `/CLAUDE.md` as the single source of truth for this repository.
+
+Key expectations:
+- Follow the repository rules and workflows defined in `/CLAUDE.md`.
+- Update `CHANGELOG.md` under `[Unreleased]` for any file modifications.
+- Keep changes minimal and aligned with existing documentation style.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **Copilot instructions file** (`.github/copilot-instructions.md`): Points Copilot users to `/CLAUDE.md` as the source of truth and reminds contributors to update `CHANGELOG.md`.
+
 - **Claude Code Releases**: Updated tracking to v2.1.123 (v2.1.120 through v2.1.123)
   - v2.1.120: Windows PowerShell fallback (no Git Bash required), claude ultrareview CI subcommand, ${CLAUDE_EFFORT} in skills
   - v2.1.121: alwaysLoad MCP config, plugin prune, PostToolUse output replacement for all tools, critical memory leak fixes


### PR DESCRIPTION
## Summary
Fixes #6

Adds .github/copilot-instructions.md pointing Copilot users to /CLAUDE.md and updates CHANGELOG.

## Changes
- add .github/copilot-instructions.md referencing /CLAUDE.md
- update CHANGELOG.md under [Unreleased]

---
🤖 Generated with Claude Code