### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,7 +782,7 @@ Use this guide critically. Experiment. Share what works for you.
 
 **Security Hooks** (31): [dangerous-actions-blocker](./examples/hooks/bash/dangerous-actions-blocker.sh), [prompt-injection-detector](./examples/hooks/bash/prompt-injection-detector.sh), [unicode-injection-scanner](./examples/hooks/bash/unicode-injection-scanner.sh), [output-secrets-scanner](./examples/hooks/bash/output-secrets-scanner.sh)...
 
-**Skills** (1): [Claudeception](https://github.com/blader/Claudeception) — Meta-skill that auto-generates skills from session discoveries ⭐
+**Skills** (2): [Claudeception](https://github.com/blader/Claudeception) — Meta-skill that auto-generates skills from session discoveries ⭐ | [mmx-cli](https://github.com/MiniMax-AI/cli) — Generate text, images, video, speech, and music via MiniMax AI
 
 **Plugins** (1): [SE-CoVe](./examples/plugins/se-cove.md) — Chain-of-Verification for independent code review (Meta AI, ACL 2024)
 


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to the community Skills list in the Examples Library so the mmx-cli skill is discoverable alongside other community skills
- Users can install via the GitHub link directly — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**1 line changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- The Skills count in the Examples Library updates from (1) to (2)
- The mmx-cli link correctly points to `https://github.com/MiniMax-AI/cli`
- No other content is affected