### PR TITLE
Fix #10: Add YouTube Skills (TranscriptAPI) to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ claude plugin install session-summary@florian-claude-tools
 | [anthropics/claude-plugins-official](https://skills.sh/anthropics/claude-plugins-official) | Plugin dev tools (3.1K installs) | CLAUDE.md audit, automation discovery |
 | [skills.sh](https://skills.sh/) | Skills marketplace | One-command install (Vercel Labs) |
 | [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) | Curation | Resource discovery |
+| [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) | 12 YouTube skills (search, transcripts, chapters) | Claude Code, Cursor, Windsurf, Cline |
 | [awesome-claude-skills](https://github.com/BehiSecc/awesome-claude-skills) | Skills taxonomy | 62 skills across 12 categories |
 | [awesome-claude-md](https://github.com/josix/awesome-claude-md) | CLAUDE.md examples | Annotated configs with scoring |
 | [AI Coding Agents Matrix](https://coding-agents-matrix.dev) | Technical comparison | Comparing 23+ alternatives |


### PR DESCRIPTION
Closes #10

Adds `youtube-skills` by ZeroPointRepo to the resources table in `README.md`.

## Changes

**`README.md`, line ~634** — inserts one row into the skills/resources table between the `awesome-claude-code` and `awesome-claude-skills` entries:

```
| [youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) | 12 YouTube skills (search, transcripts, chapters) | Claude Code, Cursor, Windsurf, Cline |
```

No other files modified.

## Motivation

The resources table lacked any YouTube-specific tooling. `youtube-skills` fills that gap with 12 ready-to-use skills covering video search, transcript retrieval (via TranscriptAPI.com), and chapter extraction — capabilities not represented elsewhere in the guide. The project is MIT-licensed, publicly maintained, and compatible with the four editors already listed throughout the guide (Claude Code, Cursor, Windsurf, Cline).

## Testing

- Rendered the Markdown locally to confirm the new row displays correctly and column alignment is preserved across the surrounding rows (`awesome-claude-code`, `awesome-claude-skills`, `awesome-claude-md`).
- Verified the linked URL (`https://github.com/ZeroPointRepo/youtube-skills`) resolves to an active repository.
- No build steps or automated tests exist for this documentation-only repo.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*