### PR TITLE
Add ctop to Complementary Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ claude plugin install session-summary      # Session analytics dashboard (15 sec
 | [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) | Curation | Resource discovery |
 | [awesome-claude-skills](https://github.com/BehiSecc/awesome-claude-skills) | Skills taxonomy | 62 skills across 12 categories |
 | [awesome-claude-md](https://github.com/josix/awesome-claude-md) | CLAUDE.md examples | Annotated configs with scoring |
+| [ctop](https://github.com/aakashadesara/ctop) | Session monitoring (htop for AI agents) | Real-time CPU, memory, tokens, costs |
 | [AI Coding Agents Matrix](https://coding-agents-matrix.dev) | Technical comparison | Comparing 23+ alternatives |
 
 **Community**: 🇫🇷 [Dev With AI](https://www.devw.ai/) — 1500+ devs on Slack, meetups in Paris, Bordeaux, Lyon


### PR DESCRIPTION
## Summary

Adds [ctop](https://github.com/aakashadesara/ctop) to the **Complementary Resources** table in the Ecosystem section.

ctop is htop for AI coding agents — monitor Claude Code and Codex CLI sessions with real-time CPU, memory, token usage, context window tracking, and cost estimates. Zero dependencies, pure Node.js.

- **Homepage**: https://aakashadesara.github.io/ctop/
- **Only README.md was modified** (one table row added to the Complementary Resources table)