### PR TITLE
fix(exports): set Typst fonts so PDF build works with Typst 0.14+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`scripts/generate-guide-exports.sh` — PDF build fails with Typst 0.14+** (`font fallback list must not be empty`). Pandoc's default Typst template leaves `mainfont`/`monofont` empty unless they are set via metadata, and Typst 0.14 made an empty font list a hard error (it was tolerated in 0.13, which is the version bundled with current Quarto on macOS). Added `-V mainfont="Libertinus Serif"` and `-V monofont="DejaVu Sans Mono"` to the `pandoc` invocation — both fonts are available out of the box on macOS and on Ubuntu (`fonts-libertinus` is pulled in by the `pandoc` apt package, `fonts-dejavu` is preinstalled). Verified end-to-end on Ubuntu 25.10 with pandoc 3.1.11 + standalone Typst 0.14.2: PDF builds successfully (556 pages, 8.4 MB) from `guide/ultimate-guide.md` v3.40.0.
+
 ### Documentation
 
 - **Claude Code Releases**: Updated tracking to v2.1.143 (from v2.1.141)

--- a/scripts/generate-guide-exports.sh
+++ b/scripts/generate-guide-exports.sh
@@ -137,6 +137,9 @@ if [ "$DO_PDF" = true ]; then
         warn "Typst not found — skipping PDF. Install: brew install typst"
     else
         log "Generating PDF (via Typst)..."
+        # Typst 0.14+ requires a non-empty font fallback list; pandoc's default
+        # Typst template leaves `mainfont`/`monofont` empty unless set. Pass
+        # widely-available fonts so the build works on Linux/macOS alike.
         pandoc \
             --from markdown-citations \
             --to pdf \
@@ -144,6 +147,8 @@ if [ "$DO_PDF" = true ]; then
             --metadata title="Claude Code Ultimate Guide" \
             --metadata author="Florian Bruniaux" \
             --metadata lang="en" \
+            -V mainfont="Libertinus Serif" \
+            -V monofont="DejaVu Sans Mono" \
             --toc \
             --toc-depth=2 \
             --pdf-engine="$TYPST_BIN" \


### PR DESCRIPTION
## Summary

`scripts/generate-guide-exports.sh --pdf` currently fails whenever the resolved `typst` binary is **>= 0.14**, aborting with:

```
error: font fallback list must not be empty
   ┌─ toPdfViaTempFile…html:47:17
   │47 │            font: font,
   │                  ^^^^
```

The root cause is in pandoc's default Typst template: it expects `mainfont`/`monofont` to be set via metadata and leaves them empty otherwise. Typst 0.13 tolerated this; **Typst 0.14 made an empty font fallback list a hard error**. The Quarto bundle on macOS still ships Typst 0.13, which is why the script has been working there, but any environment with a standalone Typst install (Linux, or a recent manual install on macOS) hits the failure.

This PR passes two widely-available fonts to pandoc so the build works on both stacks:

```bash
-V mainfont="Libertinus Serif" \
-V monofont="DejaVu Sans Mono" \
```

- `Libertinus Serif` ships with the `fonts-libertinus` package, which is pulled in transitively by `apt install pandoc` on Ubuntu/Debian, and is also commonly present on macOS.
- `DejaVu Sans Mono` is preinstalled on virtually every Linux distribution and is bundled with macOS/Quarto installs as well.

No template files, no new dependencies, no behaviour change on systems where the script was already succeeding.

## Reproduction (before this PR)

```bash
# Ubuntu 25.10, fresh install
sudo apt-get install -y pandoc           # pandoc 3.1.11
curl -fsSL -o typst.tar.xz \
  https://github.com/typst/typst/releases/latest/download/typst-x86_64-unknown-linux-musl.tar.xz
tar -xf typst.tar.xz && mv typst-*/typst ~/.local/bin/   # typst 0.14.2

git clone https://github.com/FlorianBruniaux/claude-code-ultimate-guide
cd claude-code-ultimate-guide
./scripts/generate-guide-exports.sh --pdf
# → "Error producing PDF." (Typst aborts on empty font list)
```

The pandoc invocation in the script suppresses stderr with `2>/dev/null`, so the user only sees `warn "PDF generation failed"` with no actionable hint. Running pandoc directly (without that redirect) is what surfaces the real Typst error.

## After this PR

Same environment, same command:

```
→ Source: guide/ultimate-guide.md (26224 lines, v3.40.0)
→ Generating PDF (via Typst)...
✓ PDF  → dist/claude-code-ultimate-guide.pdf (8.4M)
```

`pdfinfo` on the output:

```
Title:        Claude Code Ultimate Guide
Author:       Florian Bruniaux
Creator:      Typst 0.14.2
Pages:        556
Page size:    612 x 792 pts (letter)
```

EPUB generation is untouched.

## Files changed

- `scripts/generate-guide-exports.sh` — add `-V mainfont` / `-V monofont` to the pandoc PDF invocation, plus a short comment explaining why.
- `CHANGELOG.md` — entry under `[Unreleased] → Fixed` describing the issue and the fix.

## Test plan

- [x] PDF build succeeds on Ubuntu 25.10 with pandoc 3.1.11 + standalone Typst 0.14.2 (output: 556 pages, 8.4 MB).
- [x] EPUB build still succeeds (`./scripts/generate-guide-exports.sh --epub` → 527 KB).
- [ ] Maintainer to confirm PDF still builds on macOS with Quarto-bundled Typst 0.13 (expected: unchanged, since the fonts pinned here are available in that environment too — but worth a second run before merge).

## Notes

- I left `2>/dev/null` on the pandoc invocation as-is to keep the PR minimal, but if you'd like a follow-up I'd suggest dropping it (or gating it behind `-v`) so future Typst-side errors surface immediately instead of only as a generic "PDF generation failed" warning.
- If you'd rather pin different fonts (e.g. ones that match the whitepaper Bold Guy palette), happy to update — these two were chosen purely for cross-platform availability, not for visual consistency with the whitepapers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)