### PR TITLE
Add Vexilo · A field guide to Claude Code to Community Resources & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,12 +927,14 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 ### Community Resources
 - [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — Production configs (45k+⭐)
 - [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) — Curated links
+- [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) — Visual interactive index of 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click "Teach Claude this handbook" primes your local Claude session with the whole index in 30 seconds. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
 - [SuperClaude Framework](https://github.com/SuperClaude-Org/SuperClaude_Framework) — Behavioral modes
 
 ### Tools
 - [Ask Zread](https://zread.ai/FlorianBruniaux/claude-code-ultimate-guide) — Ask questions about this guide
 - [Interactive Quiz](./quiz/) — 271 questions
 - [Landing Site](https://cc.bruniaux.com) — Visual navigation, cheat sheets, ebooks, quiz
+- [Vexilo](https://vexilo.app/?lang=en) — Visual field guide / interactive index, complementary to your Ultimate Guide (browse-by-scenario vs read-deep-here)
 - [RSS Feed](https://cc.bruniaux.com/rss.xml) — Subscribe to guide updates, new content, and CC releases
 
 ---


### PR DESCRIPTION
## Adds Vexilo · A field guide to Claude Code to two complementary sections

[Vexilo](https://vexilo.app/?lang=en) is a visual interactive index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). The killer feature is a one-click **"Teach Claude this handbook"** that feeds the whole index into a local Claude session in 30 seconds.

### Why both sections?

- **Community Resources** — Vexilo belongs with the other curated Claude Code indexes (everything-claude-code, awesome-claude-code, SuperClaude).
- **Tools** — Vexilo is a working *navigation layer* over the ecosystem, complementary to your Ultimate Guide's deep-read approach. Different modalities for different moments.

### Complementary, not competitive

| | Ultimate Guide | Vexilo |
|---|---|---|
| Best for | Deep reading & learning | Quick lookup & decision-making |
| Format | Long-form articles | Interactive index |
| Discovery | Sequential / section-by-section | ⌘K + scenario cards |
| After reading | Bookmark for reference | Click "Teach Claude" once |

### Entry details
- URL: https://vexilo.app/?lang=en
- Companion repo (MIT): https://github.com/lilhawk7077/claude-code-resources
- v1.1.9, weekly updates
- Browser-based, zero install

### Checklist
- [x] Active project (v1.1.9)
- [x] Open and free
- [x] Directly relevant to Claude Code
- [x] Complementary to your Ultimate Guide (not a replacement)
- [x] No duplicate of existing entry