### PR TITLE
feat(mcp): add MiniMax provider and model aliases to search synonyms

### DIFF
--- a/mcp-server/src/lib/search.ts
+++ b/mcp-server/src/lib/search.ts
@@ -35,7 +35,7 @@ const SYNONYMS: Record<string, string[]> = {
   test: ['testing', 'tdd', 'bdd', 'spec', 'specs'],
   workflow: ['workflows', 'process', 'flow'],
   template: ['templates', 'example', 'examples', 'boilerplate'],
-  model: ['claude', 'opus', 'sonnet', 'haiku', 'llm'],
+  model: ['claude', 'opus', 'sonnet', 'haiku', 'llm', 'minimax', 'minimax-m3', 'minimax-m2.7'],
   key: ['keyboard', 'shortcut', 'keybinding', 'keybindings'],
 };
 


### PR DESCRIPTION
Reason: Add the MiniMax provider and its MiniMax-M3 / MiniMax-M2.7 model IDs to the MCP search model aliases so searches recognize them.

## Changes

- `mcp-server/src/lib/search.ts`: extended the `model` synonym list (used by the MCP `search_guide` / `search_examples` tools to expand model-related queries) with `minimax`, `minimax-m3`, and `minimax-m2.7`, following the existing flat-string alias pattern already used for `claude`, `opus`, `sonnet`, `haiku`, and `llm`.

The repo has no provider/endpoint registry that stores base URLs or pricing; the only "MCP search model aliases" registry is the `SYNONYMS.model` array in `mcp-server/src/lib/search.ts`, so this change follows that existing pattern. No regional endpoints, context windows, or prices are hardcoded because the alias registry does not store them.

## Checks

- `npx tsc --noEmit` — passed (no type errors)
- `npm run build` — passed (tsup build + DTS emit succeeded)
