### PR TITLE
Update retired model id in the issue-triage example workflow

### DIFF
--- a/examples/github-actions/claude-issue-triage.yml
+++ b/examples/github-actions/claude-issue-triage.yml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     env:
-      CLAUDE_MODEL: claude-3-5-sonnet-20240620
+      CLAUDE_MODEL: claude-sonnet-4-6
     steps:
       - name: Collect context & similar issues
         id: gather


### PR DESCRIPTION
The issue-triage example sets a model id that no longer resolves.

`examples/github-actions/claude-issue-triage.yml` pins `CLAUDE_MODEL: claude-3-5-sonnet-20240620`. Anthropic retired that id on 28 October 2025, and a retired id does not fall back, the API returns an error. So anyone who copies this workflow from the guide gets a failing triage action on the first run, which is a rough first experience for a tutorial.

This swaps it for `claude-sonnet-4-6`, the replacement Anthropic lists in its [deprecation table](https://platform.claude.com/docs/en/about-claude/model-deprecations). One line, nothing else touched.

I read the diff before opening it and I am happy to adjust it. What brought me here was a checker I maintain that flags retired Claude model ids across public repos, so I am saying that up front. If you would rather pin a different current model, or would rather not get this kind of contribution, tell me and I will close it.
