### PR TITLE
Add Swarmery to Session Management (third-party tools)

### DIFF
--- a/guide/ecosystem/third-party-tools.md
+++ b/guide/ecosystem/third-party-tools.md
@@ -702,6 +702,28 @@ Stop criteria: checkpoint > 10 MB/session, push overhead > 5s, or hook conflicts
 
 ---
 
+### Swarmery
+
+A local-first control plane for Claude Code: one Go binary that indexes the session transcripts Claude Code already writes, adds an approvals queue for permission prompts, and dispatches board tasks to headless agents in git worktrees.
+
+| Attribute | Details |
+|-----------|---------|
+| **Source** | [GitHub: atretyak1985/swarmery](https://github.com/atretyak1985/swarmery) / [landing page](https://atretyak1985.github.io/swarmery/) |
+| **Install** | Download the release binary, or `cd tools/swarmery && make build`; dashboard on `http://localhost:7777` |
+| **Language** | Go (daemon) + React (embedded SPA) |
+| **License** | Apache-2.0 (plugin framework) / PolyForm Noncommercial 1.0.0 (control plane) |
+
+**Key features**:
+
+- Indexes `~/.claude/projects/` transcripts into local SQLite; live tool calls, cost and diffs per session
+- One approvals queue across terminals: permission prompts become work items instead of per-window interrupts
+- Board tasks dispatched to headless Claude Code agents in isolated git worktrees
+- Plugin marketplace in the same repo: `core` (13 agents, 36 skills, 8 commands) plus 11 opt-in domain packs
+
+**Limitations**: Single machine; no team or fleet view. Reads transcripts and hooks only — no OpenTelemetry export. Control plane is not open-source-licensed (PolyForm Noncommercial); the plugin framework is.
+
+---
+
 ## Configuration Management
 
 ### claude-code-config


### PR DESCRIPTION
Adds [Swarmery](https://github.com/atretyak1985/swarmery) to `## Session Management` in `guide/ecosystem/third-party-tools.md`, after the Entire CLI entry. Swarmery is a local-first control plane for Claude Code: one Go binary that indexes the session transcripts Claude Code already writes into local SQLite, shows live tool calls, cost and diffs per session, routes permission prompts from every terminal into one approvals queue, and dispatches board tasks to headless agents in git worktrees. The same repo is a Claude Code plugin marketplace (`core` plus 11 opt-in domain packs). Licensing is split: the plugin framework is Apache-2.0, the control plane is PolyForm Noncommercial 1.0.0 — the entry states this in the attribute table and in Limitations. The entry follows the existing format for this section (H3, one-line summary, attribute table, Key features, Limitations, `---`).

Tested: markdown preview on GitHub, all links resolve, `markdownlint` (v0.37.0, repo pre-commit defaults) reports no new rule categories for the file compared with `main` (only MD013 line-length, which the existing entries in this file also trigger). No other files changed.

Demo (40 s): https://github.com/atretyak1985/swarmery/raw/main/docs/screenshots/demo.gif
